### PR TITLE
Add native method WlanSetProfileEapXmlUserData

### DIFF
--- a/Source/ManagedNativeWifi/EapXmlType.cs
+++ b/Source/ManagedNativeWifi/EapXmlType.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ManagedNativeWifi
+{
+	/// <summary>
+	/// EAP XML profile type
+	/// </summary>
+	public enum EapXmlType
+	{
+		/// <summary>
+		/// Default value
+		/// </summary>
+		/// <remarks>No constant in Wlanapi.h, but needed for EAP-TLS; seems to indicate local user only</remarks>
+		Default = 0,
+
+		/// <summary>
+		/// Set EAP host data for all users of this profile.
+		/// </summary>
+		/// <remarks>Equivalent to WLAN_SET_EAPHOST_DATA_ALL_USERS</remarks>
+		AllUsers = 1,
+	}
+
+	internal static class EapXmlTypeConverter
+	{
+		public static bool TryConvert(uint source, out EapXmlType profileType)
+		{
+			if (Enum.IsDefined(typeof(EapXmlType), (int)source))
+			{
+				profileType = (EapXmlType)source;
+				return true;
+			}
+			profileType = default;
+			return false;
+		}
+
+		public static uint ConvertBack(EapXmlType source) =>
+			(uint)source;
+	}
+}

--- a/Source/ManagedNativeWifi/NativeWifi.cs
+++ b/Source/ManagedNativeWifi/NativeWifi.cs
@@ -520,6 +520,39 @@ namespace ManagedNativeWifi
 		}
 
 		/// <summary>
+		/// Sets the Extensible Authentication Protocol (EAP) user credentials as specified by an XML string.
+		/// </summary>
+		/// <param name="interfaceId">Interface ID</param>
+		/// <param name="profileName">Profile name</param>
+		/// <param name="eapXmlType">EAP XML type</param>
+		/// <param name="userDataXml">User data XML</param>
+		/// <returns>True if successfully set. False if failed.</returns>
+		/// <remarks>
+		/// In some cases, this function may return true but fail.
+		/// This was observed when setting EapXmlType.AllUsers, but the certificate
+		/// referenced in the EAP XML was installed in the users' store.
+		/// </remarks>
+		public static bool SetProfileEapXmlUserData(Guid interfaceId, string profileName, EapXmlType eapXmlType, string userDataXml)
+		{
+			return SetProfileEapXmlUserData(null, interfaceId, profileName, eapXmlType, userDataXml);
+		}
+
+		internal static bool SetProfileEapXmlUserData(Base.WlanClient client, Guid interfaceId, string profileName, EapXmlType eapXmlType, string userDataXml)
+		{
+			if (interfaceId == Guid.Empty)
+				throw new ArgumentException(nameof(interfaceId));
+
+			if (string.IsNullOrWhiteSpace(userDataXml))
+				throw new ArgumentNullException(nameof(userDataXml));
+
+			using var container = new DisposableContainer<Base.WlanClient>(client);
+
+			var eapXmlTypeFlag = EapXmlTypeConverter.ConvertBack(eapXmlType);
+
+			return Base.SetProfileEapXmlUserData(container.Content.Handle, interfaceId, profileName, eapXmlTypeFlag, userDataXml);
+		}
+
+		/// <summary>
 		/// Sets the position of a specified wireless profile in preference order.
 		/// </summary>
 		/// <param name="interfaceId">Interface ID</param>

--- a/Source/ManagedNativeWifi/Win32/BaseMethod.cs
+++ b/Source/ManagedNativeWifi/Win32/BaseMethod.cs
@@ -340,6 +340,27 @@ namespace ManagedNativeWifi.Win32
 			return CheckResult(nameof(WlanSetProfile), result, false, pdwReasonCode);
 		}
 
+		public static bool SetProfileEapXmlUserData(SafeClientHandle clientHandle, Guid interfaceId, string profileName, uint eapXmlFlag, string userDataXml)
+		{
+			var result = WlanSetProfileEapXmlUserData(
+				clientHandle,
+				interfaceId,
+				profileName,
+				eapXmlFlag,
+				userDataXml,
+				IntPtr.Zero);
+
+			// ERROR_ACCESS_DENIED will be thrown if the caller does not have sufficient permissions.
+			// ERROR_BAD_PROFILE will be returned if the EAP XML is not valid.
+			// ERROR_INVALID_PARAMETER will be returned if any required parameter is NULL.
+			// ERROR_INVALID_HANDLE will be returned if clientHandle is not found in the handle table.
+			// ERROR_NOT_ENOUGH_MEMORY will be returned if there is not enough storage
+			// ERROR_NOT_SUPPORTED will be returned if the profile does not allow storage of user data.
+			// ERROR_SERVICE_NOT_ACTIVE will be returned if the WLAN service has not been started.
+			// RPC_STATUS will be returned for "Various error codes".
+			return CheckResult(nameof(WlanSetProfileEapXmlUserData), result, false);
+		}
+
 		public static bool SetProfilePosition(SafeClientHandle clientHandle, Guid interfaceId, string profileName, uint position)
 		{
 			var result = WlanSetProfilePosition(

--- a/Source/ManagedNativeWifi/Win32/NativeMethod.cs
+++ b/Source/ManagedNativeWifi/Win32/NativeMethod.cs
@@ -116,6 +116,15 @@ namespace ManagedNativeWifi.Win32
 			out uint pdwReasonCode); // WLAN_REASON_CODE
 
 		[DllImport("Wlanapi.dll")]
+		public static extern uint WlanSetProfileEapXmlUserData(
+			SafeClientHandle hClientHandle,
+			[MarshalAs(UnmanagedType.LPStruct), In] Guid pInterfaceGuid,
+			[MarshalAs(UnmanagedType.LPWStr)] string strProfileName,
+			uint dwFlags,
+			[MarshalAs(UnmanagedType.LPWStr)] string strEapXmlUserData,
+			IntPtr pReserved);
+
+		[DllImport("Wlanapi.dll")]
 		public static extern uint WlanSetProfilePosition(
 			SafeClientHandle hClientHandle,
 			[MarshalAs(UnmanagedType.LPStruct), In] Guid pInterfaceGuid,


### PR DESCRIPTION
Add native call to WlanSetProfileEapXmlUserData.

https://docs.microsoft.com/en-us/windows/win32/api/wlanapi/nf-wlanapi-wlansetprofileeapxmluserdata

We use this in [geteduroam](https://github.com/geteduroam/windows-app), but the changes were done locally.  
These changes might be useful for others as well, so we think it's better to share them back with you guys.

Thanks! ✌️
