### PR TITLE
Expose 802.11 PHY to BssNetworkPack

### DIFF
--- a/Source/ManagedNativeWifi/BssNetworkPack.cs
+++ b/Source/ManagedNativeWifi/BssNetworkPack.cs
@@ -57,6 +57,11 @@ namespace ManagedNativeWifi
 		public int Channel { get; }
 
 		/// <summary>
+		/// 802.11 PHY and media type
+		/// </summary>
+		public PhyType Type { get; }
+
+		/// <summary>
 		/// Constructor
 		/// </summary>
 		public BssNetworkPack(
@@ -68,7 +73,8 @@ namespace ManagedNativeWifi
 			int linkQuality,
 			int frequency,
 			float band,
-			int channel)
+			int channel,
+			PhyType type)
 		{
 			this.Interface = interfaceInfo;
 			this.Ssid = ssid;
@@ -79,6 +85,7 @@ namespace ManagedNativeWifi
 			this.Frequency = frequency;
 			this.Band = band;
 			this.Channel = channel;
+			this.Type = type;
 		}
 	}
 }

--- a/Source/ManagedNativeWifi/NativeWifi.cs
+++ b/Source/ManagedNativeWifi/NativeWifi.cs
@@ -370,7 +370,8 @@ namespace ManagedNativeWifi
 				linkQuality: (int)bssEntry.uLinkQuality,
 				frequency: (int)bssEntry.ulChCenterFrequency,
 				band: band,
-				channel: channel);
+				channel: channel,
+				type: PhyTypeConverter.Convert(bssEntry.dot11BssPhyType));
 			return true;
 		}
 


### PR DESCRIPTION
This wasn't passed through yet - allows you to see what standard the network supports (A, B, G, N, AC etc). I looked at the other unexposed fields on `WLAN_BSS_ENTRY` but they're not that interesting.

A crude mapping:
```
PhyType.Ofdm => "a"
PhyType.HrDsss => "b"
PhyType.Erp => "g"
PhyType.Ht => "n"
PhyType.Vht => "ac"
```