### PR TITLE
Document WlanSetProfileEapXmlUserData

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Available methods including asynchronous ones based on TAP.
 | EnumerateProfileRadios          | Enumerates wireless profile and related radio information in preference order.                     |
 | SetProfile                      | Sets (add or overwrite) the content of a specified wireless profile.                               |
 | SetProfilePosition              | Sets the position of a specified wireless profile in preference order.                             |
+| SetProfileEapXmlUserData        | Sets (add or overwirte) the user data (credentials) for a specified wireless profile.              |
 | RenameProfile                   | Renames a specified wireless profile.                                                              |
 | DeleteProfile                   | Deletes a specified wireless profile.                                                              |
 | ConnectNetwork                  | Attempts to connect to the wireless LAN associated to a specified wireless profile.                |

--- a/Source/ManagedNativeWifi/NativeWifi.cs
+++ b/Source/ManagedNativeWifi/NativeWifi.cs
@@ -520,7 +520,7 @@ namespace ManagedNativeWifi
 		}
 
 		/// <summary>
-		/// Sets the Extensible Authentication Protocol (EAP) user credentials as specified by an XML string.
+		/// Sets (add or overwirte) the user data (credentials) for a specified wireless profile.
 		/// </summary>
 		/// <param name="interfaceId">Interface ID</param>
 		/// <param name="profileName">Profile name</param>

--- a/Source/ManagedNativeWifi/NativeWifiPlayer.cs
+++ b/Source/ManagedNativeWifi/NativeWifiPlayer.cs
@@ -194,6 +194,12 @@ namespace ManagedNativeWifi
 			NativeWifi.SetProfilePosition(_client, interfaceId, profileName, position);
 
 		/// <summary>
+		/// Sets (add or overwirte) the user data (credentials) for a specified wireless profile.
+		/// </summary>
+		public bool SetProfileEapXmlUserData(Guid interfaceId, string profileName, EapXmlType eapXmlType, string userDataXml) =>
+			NativeWifi.SetProfileEapXmlUserData(_client, interfaceId, profileName, eapXmlType, userDataXml);
+
+		/// <summary>
 		/// Renames a specified wireless profile.
 		/// </summary>
 		public bool RenameProfile(Guid interfaceId, string oldProfileName, string newProfileName) =>


### PR DESCRIPTION
This PR documents the `WlanSetProfileEapXmlUserData` function added in my last PR.

It also adds the function to the NativeWifiPlayer, so it's consistent with all other functions.

After merging this PR, can you also release a new version on NuGet? Thanks! :pray: 