### PR TITLE
Target framework and event args

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ManagedNativeWifi is a managed implementation of [Native Wifi][1] API. It provid
 
 This library works on Windows and compatible with:
 
-.NET 5.0|.NET Standard 2.0 (including .NET Framework 4.6.1)
+.NET 6.0|.NET Standard 2.0 (including .NET Framework 4.6.1)
 -|-
 
 ## Download

--- a/Source/ManagedNativeWifi/Args/AvailabilityChangedEventArgs.cs
+++ b/Source/ManagedNativeWifi/Args/AvailabilityChangedEventArgs.cs
@@ -1,0 +1,50 @@
+﻿using System;
+
+namespace ManagedNativeWifi;
+
+/// <summary>
+/// Availability enumeration values.
+/// </summary>
+public enum Availability
+{
+	Start,
+	End,
+	/// <summary>
+	/// Network is available.
+	/// </summary>
+	Available,
+	/// <summary>
+	/// Network is not available.
+	/// </summary>
+	Unavailable
+}
+
+/// <summary>
+/// Represents event arguments for the AvailabilityChanged event.
+/// </summary>
+public class AvailabilityChangedEventArgs : EventArgs
+{
+	private readonly InterfaceInfo _interfaceInfo;
+	private readonly Availability _availability;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="T:AvailabilityChangedEventArgs" /> class.
+	/// </summary>
+	/// <param name="interfaceInfo">An instance of the <see cref="T:InterfaceInfo" /> class</param>
+	/// <param name="availability">One of the <see cref="T:Availability" /> values.</param>
+	public AvailabilityChangedEventArgs(InterfaceInfo interfaceInfo, Availability availability)
+	{
+		_interfaceInfo = interfaceInfo;
+		_availability = availability;
+	}
+
+	/// <summary>
+	/// Returns a value from the Availability enumerator.
+	/// </summary>
+	public Availability State => _availability;
+
+	/// <summary>
+	/// Returns an InterfaceInfo object.
+	/// </summary>
+	public InterfaceInfo Interface => _interfaceInfo;
+}

--- a/Source/ManagedNativeWifi/Args/ConnectionChangedEventArgs.cs
+++ b/Source/ManagedNativeWifi/Args/ConnectionChangedEventArgs.cs
@@ -1,0 +1,60 @@
+﻿using System;
+
+namespace ManagedNativeWifi;
+
+/// <summary>
+/// Connection state enumeration values.
+/// </summary>
+public enum ConnectionState
+{
+	/// <summary>
+	/// A connection attempt has started.
+	/// </summary>
+	Start,
+	/// <summary>
+	/// A connection attempt is complete.
+	/// </summary>
+	Complete,
+	/// <summary>
+	/// A connection attempt failed.
+	/// </summary>
+	Failed,
+	/// <summary>
+	/// The current connection is disconnecting.
+	/// </summary>
+	Disconnecting,
+	/// <summary>
+	/// The current connection is disconnected.
+	/// </summary>
+	Disconnected
+}
+
+/// <summary>
+/// Represents event arguments for the ConnectionChanged event.
+/// </summary>
+public class ConnectionChangedEventArgs : EventArgs
+{
+	private readonly InterfaceInfo _interfaceInfo;
+	private readonly ConnectionState _connectionState;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="T:ConnectionChangedEventArgs" /> class.
+	/// </summary>
+	/// <param name="interfaceInfo">An instance of the <see cref="T:InterfaceInfo" /> class</param>
+	/// <param name="connectionState">One of the <see cref="T:ConnectionState" /> values.</param>
+	public ConnectionChangedEventArgs(InterfaceInfo interfaceInfo, ConnectionState connectionState)
+	{
+		_interfaceInfo = interfaceInfo;
+		_connectionState = connectionState;
+	}
+
+	/// <summary>
+	/// Returns a value from the <see cref="T:ConnectionState" /> enumerator.
+	/// </summary>
+	public ConnectionState State => _connectionState;
+
+	/// <summary>
+	/// Returns an <see cref="T:InterfaceInfo" /> object.
+	/// </summary>
+	public InterfaceInfo Interface => _interfaceInfo;
+}

--- a/Source/ManagedNativeWifi/Args/InterfaceChangedEventArgs.cs
+++ b/Source/ManagedNativeWifi/Args/InterfaceChangedEventArgs.cs
@@ -1,0 +1,48 @@
+﻿using System;
+
+namespace ManagedNativeWifi;
+
+/// <summary>
+/// Interface state enumeration values.
+/// </summary>
+public enum InterfaceChangedState
+{
+	/// <summary>
+	/// An interface has arrived..
+	/// </summary>
+	Arrival,
+	/// <summary>
+	/// An interface has been removed.
+	/// </summary>
+	Removal
+}
+
+/// <summary>
+/// Represents event arguments for the InterfaceChanged event.
+/// </summary>
+public class InterfaceChangedEventArgs : EventArgs
+{
+	private readonly InterfaceInfo _interfaceInfo;
+	private readonly InterfaceChangedState _interfaceChangedState;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="T:InterfaceChangedEventArgs" /> class.
+	/// </summary>
+	/// <param name="interfaceInfo">An instance of the <see cref="T:InterfaceInfo" /> class</param>
+	/// <param name="interfaceChangedState">One of the <see cref="T:InterfaceChangedState" /> values.</param>
+	public InterfaceChangedEventArgs(InterfaceInfo interfaceInfo, InterfaceChangedState interfaceChangedState)
+	{
+		_interfaceInfo = interfaceInfo;
+		_interfaceChangedState = interfaceChangedState;
+	}
+
+	/// <summary>
+	/// Returns a value from the <see cref="T:InterfaceChangedState" /> enumerator.
+	/// </summary>
+	public InterfaceChangedState State => _interfaceChangedState;
+
+	/// <summary>
+	/// Returns an <see cref="T:InterfaceInfo" /> object.
+	/// </summary>
+	public InterfaceInfo Interface => _interfaceInfo;
+}

--- a/Source/ManagedNativeWifi/Args/ProfileChangedEventArgs.cs
+++ b/Source/ManagedNativeWifi/Args/ProfileChangedEventArgs.cs
@@ -1,0 +1,56 @@
+﻿using System;
+
+namespace ManagedNativeWifi;
+
+/// <summary>
+/// Profile state enumeration values.
+/// </summary>
+public enum ProfileState
+{
+	/// <summary>
+	/// A profile has changed.
+	/// </summary>
+	Change,
+	/// <summary>
+	/// A profile name has changed.
+	/// </summary>
+	NameChange,
+	/// <summary>
+	/// A profile has been unblocked.
+	/// </summary>
+	Unblocked,
+	/// <summary>
+	/// A profile has been blocked.
+	/// </summary>
+	Blocked
+}
+
+/// <summary>
+/// Represents event arguments for the ProfileChanged event.
+/// </summary>
+public class ProfileChangedEventArgs : EventArgs
+{
+	private readonly InterfaceInfo _interfaceInfo;
+	private readonly ProfileState _profileState;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="T:ProfileChangedEventArgs" /> class.
+	/// </summary>
+	/// <param name="interfaceInfo">An instance of the <see cref="T:InterfaceInfo" /> class</param>
+	/// <param name="profileState">One of the <see cref="T:ProfileState" /> values.</param>
+	public ProfileChangedEventArgs(InterfaceInfo interfaceInfo, ProfileState profileState)
+	{
+		_interfaceInfo = interfaceInfo;
+		_profileState = profileState;
+	}
+
+	/// <summary>
+	/// Returns a value from the <see cref="T:ProfileState" /> enumerator.
+	/// </summary>
+	public ProfileState State => _profileState;
+
+	/// <summary>
+	/// Returns an <see cref="T:InterfaceInfo" /> object.
+	/// </summary>
+	public InterfaceInfo Interface => _interfaceInfo;
+}

--- a/Source/ManagedNativeWifi/ManagedNativeWifi.csproj
+++ b/Source/ManagedNativeWifi/ManagedNativeWifi.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <Version>2.3.0</Version>
     <Authors>emoacht</Authors>


### PR DESCRIPTION
Changed target framework from NET5.0 to NET6.0

New event args objects were added to enhance the following events:
- AvailabilityChanged
- ConnectionChanged
- InterfaceChanged
- ProfileChanged

Readme file was updated to reflect changes in targeted frameworks.