### PR TITLE
Add WPA3 Enterprise values

### DIFF
--- a/Source/ManagedNativeWifi/AuthenticationAlgorithm.cs
+++ b/Source/ManagedNativeWifi/AuthenticationAlgorithm.cs
@@ -120,8 +120,8 @@ namespace ManagedNativeWifi
 				case DOT11_AUTH_ALGORITHM.DOT11_AUTH_ALGO_RSNA_PSK:
 					authenticationAlgorithm = AuthenticationAlgorithm.RSNA_PSK;
 					return true;
-				case DOT11_AUTH_ALGORITHM.DOT11_AUTH_ALGO_WPA3_ENT_192:
-					authenticationAlgorithm = AuthenticationAlgorithm.WPA3_ENT_192;
+				case DOT11_AUTH_ALGORITHM.DOT11_AUTH_ALGO_WPA3:
+					authenticationAlgorithm = AuthenticationAlgorithm.WPA3;
 					return true;
 				case DOT11_AUTH_ALGORITHM.DOT11_AUTH_ALGO_WPA3_SAE:
 					authenticationAlgorithm = AuthenticationAlgorithm.WPA3_SAE;

--- a/Source/ManagedNativeWifi/AuthenticationAlgorithm.cs
+++ b/Source/ManagedNativeWifi/AuthenticationAlgorithm.cs
@@ -60,12 +60,23 @@ namespace ManagedNativeWifi
 		/// <summary>
 		/// WPA3 algorithm
 		/// </summary>
+		[Obsolete($"WPA3 is deprecated, use {nameof(WPA3_ENT_192)} instead.")]
 		WPA3,
+
+		/// <summary>
+		/// WPA3 Enterprise 192-bits mode algorithm
+		/// </summary>
+		WPA3_ENT_192,
 
 		/// <summary>
 		/// WPA3 Simultaneous Authentication of Equals (SAE）algorithm
 		/// </summary>
 		WPA3_SAE,
+
+		/// <summary>
+		/// WPA3 Enterprise algorithm
+		/// </summary>
+		WPA3_ENT,
 
 		/// <summary>
 		/// Opportunistic Wireless Encryption (OWE) algorithm
@@ -110,11 +121,14 @@ namespace ManagedNativeWifi
 				case DOT11_AUTH_ALGORITHM.DOT11_AUTH_ALGO_RSNA_PSK:
 					authenticationAlgorithm = AuthenticationAlgorithm.RSNA_PSK;
 					return true;
-				case DOT11_AUTH_ALGORITHM.DOT11_AUTH_ALGO_WPA3:
-					authenticationAlgorithm = AuthenticationAlgorithm.WPA3;
+				case DOT11_AUTH_ALGORITHM.DOT11_AUTH_ALGO_WPA3_ENT_192:
+					authenticationAlgorithm = AuthenticationAlgorithm.WPA3_ENT_192;
 					return true;
 				case DOT11_AUTH_ALGORITHM.DOT11_AUTH_ALGO_WPA3_SAE:
 					authenticationAlgorithm = AuthenticationAlgorithm.WPA3_SAE;
+					return true;
+				case DOT11_AUTH_ALGORITHM.DOT11_AUTH_ALGO_WPA3_ENT:
+					authenticationAlgorithm = AuthenticationAlgorithm.WPA3_ENT;
 					return true;
 				case DOT11_AUTH_ALGORITHM.DOT11_AUTH_ALGO_OWE:
 					authenticationAlgorithm = AuthenticationAlgorithm.OWE;

--- a/Source/ManagedNativeWifi/AuthenticationAlgorithm.cs
+++ b/Source/ManagedNativeWifi/AuthenticationAlgorithm.cs
@@ -60,13 +60,12 @@ namespace ManagedNativeWifi
 		/// <summary>
 		/// WPA3 algorithm
 		/// </summary>
-		[Obsolete($"WPA3 is deprecated, use {nameof(WPA3_ENT_192)} instead.")]
 		WPA3,
 
 		/// <summary>
 		/// WPA3 Enterprise 192-bits mode algorithm
 		/// </summary>
-		WPA3_ENT_192,
+		WPA3_ENT_192 = WPA3,
 
 		/// <summary>
 		/// WPA3 Simultaneous Authentication of Equals (SAE）algorithm

--- a/Source/ManagedNativeWifi/Win32/NativeMethod.cs
+++ b/Source/ManagedNativeWifi/Win32/NativeMethod.cs
@@ -677,10 +677,12 @@ namespace ManagedNativeWifi.Win32
 			DOT11_AUTH_ALGO_RSNA = 6,
 			DOT11_AUTH_ALGO_RSNA_PSK = 7,
 
-			// Derived from wlantypes.h of Windows SDK (10.0.19041.0)
+			// Derived from wlantypes.h of Windows SDK (10.0.26100.0)
 			DOT11_AUTH_ALGO_WPA3 = 8,
+			DOT11_AUTH_ALGO_WPA3_ENT_192 = DOT11_AUTH_ALGO_WPA3,
 			DOT11_AUTH_ALGO_WPA3_SAE = 9,
 			DOT11_AUTH_ALGO_OWE = 10,
+			DOT11_AUTH_ALGO_WPA3_ENT = 11,
 
 			DOT11_AUTH_ALGO_IHV_START = 0x80000000,
 			DOT11_AUTH_ALGO_IHV_END = 0xffffffff


### PR DESCRIPTION
Authentication Algorithm type value WPA3 is now deprecated. Now use WPA3_ENT_192 instead for WPA3 Enterprise 192-bits mode.

[DOT11_AUTH_ALGORITHM enumeration](https://learn.microsoft.com/en-us/windows/win32/nativewifi/dot11-auth-algorithm) has new value in Windows SDK version 10.0.26100.0.

I've added an obsolete attribute to enum AuthenticationAlgorithm.WPA3. I don't know if it is necessary. We could also renamed WPA3 to WPA3_ENT_192 instead.