### PR TITLE
Fix WPA3ENT authentication method assignment

### DIFF
--- a/Source/ManagedNativeWifi/AuthenticationMethod.cs
+++ b/Source/ManagedNativeWifi/AuthenticationMethod.cs
@@ -105,7 +105,7 @@ internal static class AuthenticationMethodConverter
 				authentication = AuthenticationMethod.WPA3_Enterprise_192;
 				return true;
 			case "WPA3ENT":
-				authentication = AuthenticationMethod.WPA_Enterprise;
+				authentication = AuthenticationMethod.WPA3_Enterprise;
 				return true;
 			case "WPA3SAE":
 				authentication = AuthenticationMethod.WPA3_Personal;


### PR DESCRIPTION
Updated the `AuthenticationMethodConverter` to correctly assign the "WPA3ENT" case to `AuthenticationMethod.WPA3_Enterprise` instead of `AuthenticationMethod.WPA_Enterprise` for better accuracy in authentication method representation.