### PR TITLE
Added Radio State Changed and Signal Quality Changed events

### DIFF
--- a/Source/ManagedNativeWifi.Demo/Program.cs
+++ b/Source/ManagedNativeWifi.Demo/Program.cs
@@ -21,6 +21,7 @@ class Program
 		//TurnOff();
 
 		//CheckRadioStateEvents();
+		//CheckSignalStrengthEvents();
 	}
 
 	private static void ShowInformation()
@@ -209,5 +210,19 @@ class Program
 		Trace.WriteLine($" PhyIndex: {e.PhyRadioStateData.PhyIndex}");
 		Trace.WriteLine($" HardwareRadioOn: {e.PhyRadioStateData.HardwareOn}");
 		Trace.WriteLine($" SoftwareRadioOn: {e.PhyRadioStateData.SoftwareOn}}}");
+	}
+
+	private static void CheckSignalStrengthEvents()
+	{
+		using var player = new NativeWifiPlayer();
+		player.SignalQualityChanged += Player_SignalQualityChanged; ;
+		Console.ReadLine();
+		player.SignalQualityChanged -= Player_SignalQualityChanged;
+	}
+
+	private static void Player_SignalQualityChanged(object sender, SignalQualityChangedEventArgs e)
+	{
+		Trace.WriteLine($"{{Interface: ({e.InterfaceId})");
+		Trace.WriteLine($"SignalQuality: {e.SignalQuality})}}");
 	}
 }

--- a/Source/ManagedNativeWifi.Demo/Program.cs
+++ b/Source/ManagedNativeWifi.Demo/Program.cs
@@ -19,6 +19,8 @@ class Program
 
 		//TurnOn();
 		//TurnOff();
+
+		//CheckRadioStateEvents();
 	}
 
 	private static void ShowInformation()
@@ -191,5 +193,21 @@ class Program
 				Trace.WriteLine("Turn off: Unauthorized");
 			}
 		}
+	}
+
+	private static void CheckRadioStateEvents()
+	{
+		using var player = new NativeWifiPlayer();
+		player.RadioStateChanged += Player_RadioStateChanged;
+		Console.ReadLine();
+		player.RadioStateChanged -= Player_RadioStateChanged;
+	}
+
+	private static void Player_RadioStateChanged(object sender, RadioStateChangedEventArgs e)
+	{
+		Trace.WriteLine($"{{Interface: ({e.InterfaceId})");
+		Trace.WriteLine($" PhyIndex: {e.PhyRadioStateData.PhyIndex}");
+		Trace.WriteLine($" HardwareRadioOn: {e.PhyRadioStateData.HardwareOn}");
+		Trace.WriteLine($" SoftwareRadioOn: {e.PhyRadioStateData.SoftwareOn}}}");
 	}
 }

--- a/Source/ManagedNativeWifi.Demo/Program.cs
+++ b/Source/ManagedNativeWifi.Demo/Program.cs
@@ -207,9 +207,9 @@ class Program
 	private static void Player_RadioStateChanged(object sender, RadioStateChangedEventArgs e)
 	{
 		Trace.WriteLine($"{{Interface: ({e.InterfaceId})");
-		Trace.WriteLine($" PhyIndex: {e.PhyRadioStateData.PhyIndex}");
-		Trace.WriteLine($" HardwareRadioOn: {e.PhyRadioStateData.HardwareOn}");
-		Trace.WriteLine($" SoftwareRadioOn: {e.PhyRadioStateData.SoftwareOn}}}");
+		Trace.WriteLine($" PhyIndex: {e.PhyRadioStateInfo.PhyIndex}");
+		Trace.WriteLine($" HardwareRadioOn: {e.PhyRadioStateInfo.HardwareOn}");
+		Trace.WriteLine($" SoftwareRadioOn: {e.PhyRadioStateInfo.SoftwareOn}}}");
 	}
 
 	private static void CheckSignalStrengthEvents()

--- a/Source/ManagedNativeWifi/NativeWifiPlayer.cs
+++ b/Source/ManagedNativeWifi/NativeWifiPlayer.cs
@@ -64,116 +64,90 @@ public class NativeWifiPlayer : IDisposable
 
 	private void OnNotificationReceived(object sender, WLAN_NOTIFICATION_DATA e)
 	{
-		// Check the notification source
-		if (e.NotificationSource == WLAN_NOTIFICATION_SOURCE_MSM)
+		switch (e.NotificationSource)
 		{
-			var msmCode = (WLAN_NOTIFICATION_MSM)e.NotificationCode;
+			case WLAN_NOTIFICATION_SOURCE_ACM:
+				var acmCode = (WLAN_NOTIFICATION_ACM)e.NotificationCode;
+				Debug.WriteLine($"Notification ACM Received: {acmCode}");
 
-			Debug.WriteLine($"Notification MSM Received: {msmCode}");
+				switch (acmCode)
+				{
+					case WLAN_NOTIFICATION_ACM.wlan_notification_acm_scan_list_refresh:
+						NetworkRefreshed?.Invoke(this, EventArgs.Empty);
+						break;
 
-			switch (msmCode)
-			{
-				case WLAN_NOTIFICATION_MSM.wlan_notification_msm_radio_state_change:
-					// Ensure pData is not null
-					if (e.pData != IntPtr.Zero)
-					{
-						// The pData points to a WLAN_PHY_RADIO_STATE structure
-						var radioState = new PhyRadioStateData(Marshal.PtrToStructure<WLAN_PHY_RADIO_STATE>(e.pData));
+					case WLAN_NOTIFICATION_ACM.wlan_notification_acm_network_available:
+						AvailabilityChanged?.Invoke(this, new AvailabilityChangedEventArgs(e.InterfaceGuid, AvailabilityChangedState.Available));
+						break;
+					case WLAN_NOTIFICATION_ACM.wlan_notification_acm_network_not_available:
+						AvailabilityChanged?.Invoke(this, new AvailabilityChangedEventArgs(e.InterfaceGuid, AvailabilityChangedState.Unavailable));
+						break;
 
+					case WLAN_NOTIFICATION_ACM.wlan_notification_acm_interface_arrival:
+						InterfaceChanged?.Invoke(this, new InterfaceChangedEventArgs(e.InterfaceGuid, InterfaceChangedState.Arrived));
+						break;
+					case WLAN_NOTIFICATION_ACM.wlan_notification_acm_interface_removal:
+						InterfaceChanged?.Invoke(this, new InterfaceChangedEventArgs(e.InterfaceGuid, InterfaceChangedState.Removed));
+						break;
+
+					case WLAN_NOTIFICATION_ACM.wlan_notification_acm_connection_start:
+					case WLAN_NOTIFICATION_ACM.wlan_notification_acm_connection_complete:
+					case WLAN_NOTIFICATION_ACM.wlan_notification_acm_connection_attempt_fail:
+					case WLAN_NOTIFICATION_ACM.wlan_notification_acm_disconnecting:
+					case WLAN_NOTIFICATION_ACM.wlan_notification_acm_disconnected:
+						var data = new ConnectionNotificationData(Marshal.PtrToStructure<WLAN_CONNECTION_NOTIFICATION_DATA>(e.pData));
+						switch (acmCode)
+						{
+							case WLAN_NOTIFICATION_ACM.wlan_notification_acm_connection_start:
+								ConnectionChanged?.Invoke(this, new ConnectionChangedEventArgs(e.InterfaceGuid, ConnectionChangedState.Started, data));
+								break;
+							case WLAN_NOTIFICATION_ACM.wlan_notification_acm_connection_complete:
+								ConnectionChanged?.Invoke(this, new ConnectionChangedEventArgs(e.InterfaceGuid, ConnectionChangedState.Completed, data));
+								break;
+							case WLAN_NOTIFICATION_ACM.wlan_notification_acm_connection_attempt_fail:
+								ConnectionChanged?.Invoke(this, new ConnectionChangedEventArgs(e.InterfaceGuid, ConnectionChangedState.Failed, data));
+								break;
+							case WLAN_NOTIFICATION_ACM.wlan_notification_acm_disconnecting:
+								ConnectionChanged?.Invoke(this, new ConnectionChangedEventArgs(e.InterfaceGuid, ConnectionChangedState.Disconnecting, data));
+								break;
+							case WLAN_NOTIFICATION_ACM.wlan_notification_acm_disconnected:
+								ConnectionChanged?.Invoke(this, new ConnectionChangedEventArgs(e.InterfaceGuid, ConnectionChangedState.Disconnected, data));
+								break;
+						}
+						break;
+
+					case WLAN_NOTIFICATION_ACM.wlan_notification_acm_profile_change:
+						ProfileChanged?.Invoke(this, new ProfileChangedEventArgs(e.InterfaceGuid, ProfileChangedState.Changed));
+						break;
+					case WLAN_NOTIFICATION_ACM.wlan_notification_acm_profile_name_change:
+						ProfileChanged?.Invoke(this, new ProfileChangedEventArgs(e.InterfaceGuid, ProfileChangedState.NameChanged));
+						break;
+					case WLAN_NOTIFICATION_ACM.wlan_notification_acm_profile_unblocked:
+						ProfileChanged?.Invoke(this, new ProfileChangedEventArgs(e.InterfaceGuid, ProfileChangedState.Unblocked));
+						break;
+					case WLAN_NOTIFICATION_ACM.wlan_notification_acm_profile_blocked:
+						ProfileChanged?.Invoke(this, new ProfileChangedEventArgs(e.InterfaceGuid, ProfileChangedState.Blocked));
+						break;
+				}
+				break;
+
+			case WLAN_NOTIFICATION_SOURCE_MSM:
+				var msmCode = (WLAN_NOTIFICATION_MSM)e.NotificationCode;
+				Debug.WriteLine($"Notification MSM Received: {msmCode}");
+
+				switch (msmCode)
+				{
+					case WLAN_NOTIFICATION_MSM.wlan_notification_msm_radio_state_change:
+						var radioState = new PhyRadioStateInfo(Marshal.PtrToStructure<WLAN_PHY_RADIO_STATE>(e.pData));
 						RadioStateChanged?.Invoke(this, new RadioStateChangedEventArgs(e.InterfaceGuid, radioState));
-					}
-					else
-					{
-						Debug.WriteLine("Notification data pointer (pData) is null.");
-					}
-					break;
+						break;
 
-				case WLAN_NOTIFICATION_MSM.wlan_notification_msm_signal_quality_change:
-					// Handle signal quality change
-					if (e.pData != IntPtr.Zero)
-					{
-						// The pData points to a ULONG value for the signal quality (0-100)
+					case WLAN_NOTIFICATION_MSM.wlan_notification_msm_signal_quality_change:
 						int signalQuality = Marshal.ReadInt32(e.pData);
 						SignalQualityChanged?.Invoke(this, new SignalQualityChangedEventArgs(e.InterfaceGuid, signalQuality));
-					}
-					else
-					{
-						Debug.WriteLine("Notification data pointer (pData) is null.");
-					}
-					break;
-				// Add other MSM notifications here if needed
-				default:
-					Debug.WriteLine($"Unhandled MSM Notification: {msmCode}");
-					break;
-			}
-		}
-		else if (e.NotificationSource == WLAN_NOTIFICATION_SOURCE_ACM)
-		{
-			var acmCode = (WLAN_NOTIFICATION_ACM)e.NotificationCode;
-
-			Debug.WriteLine($"Notification ACM Received: {acmCode}");
-
-			switch (acmCode)
-			{
-				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_scan_list_refresh:
-					NetworkRefreshed?.Invoke(this, EventArgs.Empty);
-					break;
-
-				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_network_available:
-					AvailabilityChanged?.Invoke(this, new AvailabilityChangedEventArgs(e.InterfaceGuid, AvailabilityChangedState.Available));
-					break;
-				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_network_not_available:
-					AvailabilityChanged?.Invoke(this, new AvailabilityChangedEventArgs(e.InterfaceGuid, AvailabilityChangedState.Unavailable));
-					break;
-
-				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_interface_arrival:
-					InterfaceChanged?.Invoke(this, new InterfaceChangedEventArgs(e.InterfaceGuid, InterfaceChangedState.Arrived));
-					break;
-				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_interface_removal:
-					InterfaceChanged?.Invoke(this, new InterfaceChangedEventArgs(e.InterfaceGuid, InterfaceChangedState.Removed));
-					break;
-
-				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_connection_start:
-				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_connection_complete:
-				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_connection_attempt_fail:
-				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_disconnecting:
-				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_disconnected:
-					// The pData of WLAN_NOTIFICATION_DATA points to a WLAN_CONNECTION_NOTIFICATION_DATA structure.
-					var data = new ConnectionNotificationData(Marshal.PtrToStructure<WLAN_CONNECTION_NOTIFICATION_DATA>(e.pData));
-
-					switch (acmCode)
-					{
-						case WLAN_NOTIFICATION_ACM.wlan_notification_acm_connection_start:
-							ConnectionChanged?.Invoke(this, new ConnectionChangedEventArgs(e.InterfaceGuid, ConnectionChangedState.Started, data));
-							break;
-						case WLAN_NOTIFICATION_ACM.wlan_notification_acm_connection_complete:
-							ConnectionChanged?.Invoke(this, new ConnectionChangedEventArgs(e.InterfaceGuid, ConnectionChangedState.Completed, data));
-							break;
-						case WLAN_NOTIFICATION_ACM.wlan_notification_acm_connection_attempt_fail:
-							ConnectionChanged?.Invoke(this, new ConnectionChangedEventArgs(e.InterfaceGuid, ConnectionChangedState.Failed, data));
-							break;
-						case WLAN_NOTIFICATION_ACM.wlan_notification_acm_disconnecting:
-							ConnectionChanged?.Invoke(this, new ConnectionChangedEventArgs(e.InterfaceGuid, ConnectionChangedState.Disconnecting, data));
-							break;
-						case WLAN_NOTIFICATION_ACM.wlan_notification_acm_disconnected:
-							ConnectionChanged?.Invoke(this, new ConnectionChangedEventArgs(e.InterfaceGuid, ConnectionChangedState.Disconnected, data));
-							break;
-					}
-					break;
-
-				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_profile_change:
-					ProfileChanged?.Invoke(this, new ProfileChangedEventArgs(e.InterfaceGuid, ProfileChangedState.Changed));
-					break;
-				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_profile_name_change:
-					ProfileChanged?.Invoke(this, new ProfileChangedEventArgs(e.InterfaceGuid, ProfileChangedState.NameChanged));
-					break;
-				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_profile_unblocked:
-					ProfileChanged?.Invoke(this, new ProfileChangedEventArgs(e.InterfaceGuid, ProfileChangedState.Unblocked));
-					break;
-				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_profile_blocked:
-					ProfileChanged?.Invoke(this, new ProfileChangedEventArgs(e.InterfaceGuid, ProfileChangedState.Blocked));
-					break;
-			}
+						break;
+				}
+				break;
 		}
 	}
 

--- a/Source/ManagedNativeWifi/NativeWifiPlayer.cs
+++ b/Source/ManagedNativeWifi/NativeWifiPlayer.cs
@@ -52,71 +52,110 @@ public class NativeWifiPlayer : IDisposable
 	/// </summary>
 	public event EventHandler<ProfileChangedEventArgs> ProfileChanged;
 
+	/// <summary>
+	/// Occurs when the radio state of a wireless interface is changed.
+	/// </summary>
+	public event EventHandler<RadioStateChangedEventArgs> RadioStateChanged;
+
 	private void OnNotificationReceived(object sender, WLAN_NOTIFICATION_DATA e)
 	{
-		Debug.WriteLine($"NotificationReceived: {(WLAN_NOTIFICATION_ACM)e.NotificationCode}");
-
-		var code = (WLAN_NOTIFICATION_ACM)e.NotificationCode;
-		switch (code)
+		// Check the notification source
+		if (e.NotificationSource == WLAN_NOTIFICATION_SOURCE_MSM)
 		{
-			case WLAN_NOTIFICATION_ACM.wlan_notification_acm_scan_list_refresh:
-				NetworkRefreshed?.Invoke(this, EventArgs.Empty);
-				break;
+			var msmCode = (WLAN_NOTIFICATION_MSM)e.NotificationCode;
 
-			case WLAN_NOTIFICATION_ACM.wlan_notification_acm_network_available:
-				AvailabilityChanged?.Invoke(this, new AvailabilityChangedEventArgs(e.InterfaceGuid, AvailabilityChangedState.Available));
-				break;
-			case WLAN_NOTIFICATION_ACM.wlan_notification_acm_network_not_available:
-				AvailabilityChanged?.Invoke(this, new AvailabilityChangedEventArgs(e.InterfaceGuid, AvailabilityChangedState.Unavailable));
-				break;
+			Debug.WriteLine($"Notification MSM Received: {msmCode}");
 
-			case WLAN_NOTIFICATION_ACM.wlan_notification_acm_interface_arrival:
-				InterfaceChanged?.Invoke(this, new InterfaceChangedEventArgs(e.InterfaceGuid, InterfaceChangedState.Arrived));
-				break;
-			case WLAN_NOTIFICATION_ACM.wlan_notification_acm_interface_removal:
-				InterfaceChanged?.Invoke(this, new InterfaceChangedEventArgs(e.InterfaceGuid, InterfaceChangedState.Removed));
-				break;
+			switch (msmCode)
+			{
+				case WLAN_NOTIFICATION_MSM.wlan_notification_msm_radio_state_change:
+					// Ensure pData is not null
+					if (e.pData != IntPtr.Zero)
+					{
+					// The pData points to a WLAN_PHY_RADIO_STATE structure
+						var radioState = new PhyRadioStateData(Marshal.PtrToStructure<WLAN_PHY_RADIO_STATE>(e.pData));
 
-			case WLAN_NOTIFICATION_ACM.wlan_notification_acm_connection_start:
-			case WLAN_NOTIFICATION_ACM.wlan_notification_acm_connection_complete:
-			case WLAN_NOTIFICATION_ACM.wlan_notification_acm_connection_attempt_fail:
-			case WLAN_NOTIFICATION_ACM.wlan_notification_acm_disconnecting:
-			case WLAN_NOTIFICATION_ACM.wlan_notification_acm_disconnected:
-				// The pData of WLAN_NOTIFICATION_DATA points to a WLAN_CONNECTION_NOTIFICATION_DATA structure.
-				var data = new ConnectionNotificationData(Marshal.PtrToStructure<WLAN_CONNECTION_NOTIFICATION_DATA>(e.pData));
+						RadioStateChanged?.Invoke(this, new RadioStateChangedEventArgs(e.InterfaceGuid, radioState));
+					}
+					else
+					{
+						Debug.WriteLine("Notification data pointer (pData) is null.");
+					}
+					break;
 
-				switch (code)
-				{
-					case WLAN_NOTIFICATION_ACM.wlan_notification_acm_connection_start:
-						ConnectionChanged?.Invoke(this, new ConnectionChangedEventArgs(e.InterfaceGuid, ConnectionChangedState.Started, data));
-						break;
-					case WLAN_NOTIFICATION_ACM.wlan_notification_acm_connection_complete:
-						ConnectionChanged?.Invoke(this, new ConnectionChangedEventArgs(e.InterfaceGuid, ConnectionChangedState.Completed, data));
-						break;
-					case WLAN_NOTIFICATION_ACM.wlan_notification_acm_connection_attempt_fail:
-						ConnectionChanged?.Invoke(this, new ConnectionChangedEventArgs(e.InterfaceGuid, ConnectionChangedState.Failed, data));
-						break;
-					case WLAN_NOTIFICATION_ACM.wlan_notification_acm_disconnecting:
-						ConnectionChanged?.Invoke(this, new ConnectionChangedEventArgs(e.InterfaceGuid, ConnectionChangedState.Disconnecting, data));
-						break;
-					case WLAN_NOTIFICATION_ACM.wlan_notification_acm_disconnected:
-						ConnectionChanged?.Invoke(this, new ConnectionChangedEventArgs(e.InterfaceGuid, ConnectionChangedState.Disconnected, data));
-						break;
-				}
-				break;
+				// Add other MSM notifications here if needed
+				default:
+					Debug.WriteLine($"Unhandled MSM Notification: {msmCode}");
+					break;
+			}
+		}
+		else if (e.NotificationSource == WLAN_NOTIFICATION_SOURCE_ACM)
+		{
+			var acmCode = (WLAN_NOTIFICATION_ACM)e.NotificationCode;
 
-			case WLAN_NOTIFICATION_ACM.wlan_notification_acm_profile_change:
-				ProfileChanged?.Invoke(this, new ProfileChangedEventArgs(e.InterfaceGuid, ProfileChangedState.Changed));
-				break;
-			case WLAN_NOTIFICATION_ACM.wlan_notification_acm_profile_name_change:
-				ProfileChanged?.Invoke(this, new ProfileChangedEventArgs(e.InterfaceGuid, ProfileChangedState.NameChanged));
-				break;
-			case WLAN_NOTIFICATION_ACM.wlan_notification_acm_profile_unblocked:
-				ProfileChanged?.Invoke(this, new ProfileChangedEventArgs(e.InterfaceGuid, ProfileChangedState.Unblocked));
-				break;
-			case WLAN_NOTIFICATION_ACM.wlan_notification_acm_profile_blocked:
-				ProfileChanged?.Invoke(this, new ProfileChangedEventArgs(e.InterfaceGuid, ProfileChangedState.Blocked));
-				break;
+			Debug.WriteLine($"Notification ACM Received: {acmCode}");
+
+			switch (acmCode)
+			{
+				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_scan_list_refresh:
+					NetworkRefreshed?.Invoke(this, EventArgs.Empty);
+					break;
+
+				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_network_available:
+					AvailabilityChanged?.Invoke(this, new AvailabilityChangedEventArgs(e.InterfaceGuid, AvailabilityChangedState.Available));
+					break;
+				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_network_not_available:
+					AvailabilityChanged?.Invoke(this, new AvailabilityChangedEventArgs(e.InterfaceGuid, AvailabilityChangedState.Unavailable));
+					break;
+
+				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_interface_arrival:
+					InterfaceChanged?.Invoke(this, new InterfaceChangedEventArgs(e.InterfaceGuid, InterfaceChangedState.Arrived));
+					break;
+				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_interface_removal:
+					InterfaceChanged?.Invoke(this, new InterfaceChangedEventArgs(e.InterfaceGuid, InterfaceChangedState.Removed));
+					break;
+
+				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_connection_start:
+				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_connection_complete:
+				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_connection_attempt_fail:
+				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_disconnecting:
+				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_disconnected:
+					// The pData of WLAN_NOTIFICATION_DATA points to a WLAN_CONNECTION_NOTIFICATION_DATA structure.
+					var data = new ConnectionNotificationData(Marshal.PtrToStructure<WLAN_CONNECTION_NOTIFICATION_DATA>(e.pData));
+
+					switch (acmCode)
+					{
+						case WLAN_NOTIFICATION_ACM.wlan_notification_acm_connection_start:
+							ConnectionChanged?.Invoke(this, new ConnectionChangedEventArgs(e.InterfaceGuid, ConnectionChangedState.Started, data));
+							break;
+						case WLAN_NOTIFICATION_ACM.wlan_notification_acm_connection_complete:
+							ConnectionChanged?.Invoke(this, new ConnectionChangedEventArgs(e.InterfaceGuid, ConnectionChangedState.Completed, data));
+							break;
+						case WLAN_NOTIFICATION_ACM.wlan_notification_acm_connection_attempt_fail:
+							ConnectionChanged?.Invoke(this, new ConnectionChangedEventArgs(e.InterfaceGuid, ConnectionChangedState.Failed, data));
+							break;
+						case WLAN_NOTIFICATION_ACM.wlan_notification_acm_disconnecting:
+							ConnectionChanged?.Invoke(this, new ConnectionChangedEventArgs(e.InterfaceGuid, ConnectionChangedState.Disconnecting, data));
+							break;
+						case WLAN_NOTIFICATION_ACM.wlan_notification_acm_disconnected:
+							ConnectionChanged?.Invoke(this, new ConnectionChangedEventArgs(e.InterfaceGuid, ConnectionChangedState.Disconnected, data));
+							break;
+					}
+					break;
+
+				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_profile_change:
+					ProfileChanged?.Invoke(this, new ProfileChangedEventArgs(e.InterfaceGuid, ProfileChangedState.Changed));
+					break;
+				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_profile_name_change:
+					ProfileChanged?.Invoke(this, new ProfileChangedEventArgs(e.InterfaceGuid, ProfileChangedState.NameChanged));
+					break;
+				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_profile_unblocked:
+					ProfileChanged?.Invoke(this, new ProfileChangedEventArgs(e.InterfaceGuid, ProfileChangedState.Unblocked));
+					break;
+				case WLAN_NOTIFICATION_ACM.wlan_notification_acm_profile_blocked:
+					ProfileChanged?.Invoke(this, new ProfileChangedEventArgs(e.InterfaceGuid, ProfileChangedState.Blocked));
+					break;
+			}
 		}
 	}
 

--- a/Source/ManagedNativeWifi/NativeWifiPlayer.cs
+++ b/Source/ManagedNativeWifi/NativeWifiPlayer.cs
@@ -57,6 +57,11 @@ public class NativeWifiPlayer : IDisposable
 	/// </summary>
 	public event EventHandler<RadioStateChangedEventArgs> RadioStateChanged;
 
+	/// <summary>
+	/// Occurs when the signal quality of a wireless interface changes.
+	/// </summary>
+	public event EventHandler<SignalQualityChangedEventArgs> SignalQualityChanged;
+
 	private void OnNotificationReceived(object sender, WLAN_NOTIFICATION_DATA e)
 	{
 		// Check the notification source
@@ -72,7 +77,7 @@ public class NativeWifiPlayer : IDisposable
 					// Ensure pData is not null
 					if (e.pData != IntPtr.Zero)
 					{
-					// The pData points to a WLAN_PHY_RADIO_STATE structure
+						// The pData points to a WLAN_PHY_RADIO_STATE structure
 						var radioState = new PhyRadioStateData(Marshal.PtrToStructure<WLAN_PHY_RADIO_STATE>(e.pData));
 
 						RadioStateChanged?.Invoke(this, new RadioStateChangedEventArgs(e.InterfaceGuid, radioState));
@@ -83,6 +88,19 @@ public class NativeWifiPlayer : IDisposable
 					}
 					break;
 
+				case WLAN_NOTIFICATION_MSM.wlan_notification_msm_signal_quality_change:
+					// Handle signal quality change
+					if (e.pData != IntPtr.Zero)
+					{
+						// The pData points to a ULONG value for the signal quality (0-100)
+						int signalQuality = Marshal.ReadInt32(e.pData);
+						SignalQualityChanged?.Invoke(this, new SignalQualityChangedEventArgs(e.InterfaceGuid, signalQuality));
+					}
+					else
+					{
+						Debug.WriteLine("Notification data pointer (pData) is null.");
+					}
+					break;
 				// Add other MSM notifications here if needed
 				default:
 					Debug.WriteLine($"Unhandled MSM Notification: {msmCode}");

--- a/Source/ManagedNativeWifi/PhyRadioStateData.cs
+++ b/Source/ManagedNativeWifi/PhyRadioStateData.cs
@@ -1,0 +1,32 @@
+﻿using static ManagedNativeWifi.Win32.NativeMethod;
+
+namespace ManagedNativeWifi;
+
+/// <summary>
+/// Wireless radio information
+/// </summary>
+public class PhyRadioStateData
+{
+	/// <summary>
+	/// The index of the PHY type on which the radio state is being set or queried.
+	/// </summary>
+	public uint PhyIndex { get; }
+
+	/// <summary>
+	/// Whether hardware radio state is on
+	/// </summary>
+	public bool HardwareOn { get; }
+
+	/// <summary>
+	/// Whether software radio state is on
+	/// </summary>
+	public bool SoftwareOn { get; }
+
+	internal PhyRadioStateData(WLAN_PHY_RADIO_STATE data)
+	{
+		PhyIndex = data.dwPhyIndex;
+		HardwareOn = data.dot11HardwareRadioState == DOT11_RADIO_STATE.dot11_radio_state_on;
+		SoftwareOn = data.dot11SoftwareRadioState == DOT11_RADIO_STATE.dot11_radio_state_on;
+	}
+}
+

--- a/Source/ManagedNativeWifi/PhyRadioStateInfo.cs
+++ b/Source/ManagedNativeWifi/PhyRadioStateInfo.cs
@@ -5,10 +5,10 @@ namespace ManagedNativeWifi;
 /// <summary>
 /// Wireless radio information
 /// </summary>
-public class PhyRadioStateData
+public class PhyRadioStateInfo
 {
 	/// <summary>
-	/// The index of the PHY type on which the radio state is being set or queried.
+	/// The index of the PHY type on which the radio state is being set or queried
 	/// </summary>
 	public uint PhyIndex { get; }
 
@@ -22,7 +22,7 @@ public class PhyRadioStateData
 	/// </summary>
 	public bool SoftwareOn { get; }
 
-	internal PhyRadioStateData(WLAN_PHY_RADIO_STATE data)
+	internal PhyRadioStateInfo(WLAN_PHY_RADIO_STATE data)
 	{
 		PhyIndex = data.dwPhyIndex;
 		HardwareOn = data.dot11HardwareRadioState == DOT11_RADIO_STATE.dot11_radio_state_on;

--- a/Source/ManagedNativeWifi/RadioStateChangedEventArgs.cs
+++ b/Source/ManagedNativeWifi/RadioStateChangedEventArgs.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace ManagedNativeWifi;
+
+/// <summary>
+/// Provides data for the RadioStateChanged event.
+/// </summary>
+public class RadioStateChangedEventArgs : EventArgs
+{
+	/// <summary>
+	/// Associated wireless interface ID
+	/// </summary>
+	public Guid InterfaceId { get; }
+
+	/// <summary>
+	/// Physical Radio State Data
+	/// </summary>
+	public PhyRadioStateData PhyRadioStateData { get; }
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="T:RadioStateChangedEventArgs"/> class.
+	/// </summary>
+	/// <param name="interfaceId">Interface ID</param>
+	/// <param name="phyRadioStateData">Physical Radio State Data</param>
+	public RadioStateChangedEventArgs(Guid interfaceId, PhyRadioStateData phyRadioStateData)
+	{
+		InterfaceId = interfaceId;
+		PhyRadioStateData = phyRadioStateData;
+	}
+}

--- a/Source/ManagedNativeWifi/RadioStateChangedEventArgs.cs
+++ b/Source/ManagedNativeWifi/RadioStateChangedEventArgs.cs
@@ -13,18 +13,18 @@ public class RadioStateChangedEventArgs : EventArgs
 	public Guid InterfaceId { get; }
 
 	/// <summary>
-	/// Physical Radio State Data
+	/// Physical Radio State Info
 	/// </summary>
-	public PhyRadioStateData PhyRadioStateData { get; }
+	public PhyRadioStateInfo PhyRadioStateInfo { get; }
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="T:RadioStateChangedEventArgs"/> class.
 	/// </summary>
 	/// <param name="interfaceId">Interface ID</param>
-	/// <param name="phyRadioStateData">Physical Radio State Data</param>
-	public RadioStateChangedEventArgs(Guid interfaceId, PhyRadioStateData phyRadioStateData)
+	/// <param name="phyRadioStateInfo">Physical Radio State Info</param>
+	public RadioStateChangedEventArgs(Guid interfaceId, PhyRadioStateInfo phyRadioStateInfo)
 	{
 		InterfaceId = interfaceId;
-		PhyRadioStateData = phyRadioStateData;
+		PhyRadioStateInfo = phyRadioStateInfo;
 	}
 }

--- a/Source/ManagedNativeWifi/SignalQualityChangedEventArgs.cs
+++ b/Source/ManagedNativeWifi/SignalQualityChangedEventArgs.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace ManagedNativeWifi;
+
+/// <summary>
+/// Provides data for the SignalQualityChanged event.
+/// </summary>
+public class SignalQualityChangedEventArgs : EventArgs
+{
+	/// <summary>
+	/// Associated wireless interface ID.
+	/// </summary>
+	public Guid InterfaceId { get; }
+
+	/// <summary>
+	/// New signal quality (0-100).
+	/// </summary>
+	public int SignalQuality { get; }
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="SignalQualityChangedEventArgs"/> class.
+	/// </summary>
+	/// <param name="interfaceId">Interface ID.</param>
+	/// <param name="signalQuality">New signal quality.</param>
+	public SignalQualityChangedEventArgs(Guid interfaceId, int signalQuality)
+	{
+		InterfaceId = interfaceId;
+		SignalQuality = signalQuality;
+	}
+}

--- a/Source/ManagedNativeWifi/SignalQualityChangedEventArgs.cs
+++ b/Source/ManagedNativeWifi/SignalQualityChangedEventArgs.cs
@@ -8,20 +8,20 @@ namespace ManagedNativeWifi;
 public class SignalQualityChangedEventArgs : EventArgs
 {
 	/// <summary>
-	/// Associated wireless interface ID.
+	/// Associated wireless interface ID
 	/// </summary>
 	public Guid InterfaceId { get; }
 
 	/// <summary>
-	/// New signal quality (0-100).
+	/// New signal quality (0-100)
 	/// </summary>
 	public int SignalQuality { get; }
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="SignalQualityChangedEventArgs"/> class.
 	/// </summary>
-	/// <param name="interfaceId">Interface ID.</param>
-	/// <param name="signalQuality">New signal quality.</param>
+	/// <param name="interfaceId">Interface ID</param>
+	/// <param name="signalQuality">New signal quality</param>
 	public SignalQualityChangedEventArgs(Guid interfaceId, int signalQuality)
 	{
 		InterfaceId = interfaceId;

--- a/Source/ManagedNativeWifi/Win32/BaseMethod.cs
+++ b/Source/ManagedNativeWifi/Win32/BaseMethod.cs
@@ -77,15 +77,16 @@ internal static class BaseMethod
 			_notificationCallback = new WLAN_NOTIFICATION_CALLBACK((data, context) =>
 			{
 				var notificationData = Marshal.PtrToStructure<WLAN_NOTIFICATION_DATA>(data);
-				if (notificationData.NotificationSource is not WLAN_NOTIFICATION_SOURCE_ACM)
-					return;
-
-				NotificationReceived?.Invoke(null, notificationData);
+				if (notificationData.NotificationSource == WLAN_NOTIFICATION_SOURCE_ACM ||
+					notificationData.NotificationSource == WLAN_NOTIFICATION_SOURCE_MSM)
+				{
+					NotificationReceived?.Invoke(null, notificationData);
+				}
 			});
 
 			var result = WlanRegisterNotification(
 				Handle,
-				WLAN_NOTIFICATION_SOURCE_ACM,
+				WLAN_NOTIFICATION_SOURCE_ACM | WLAN_NOTIFICATION_SOURCE_MSM,
 				false,
 				_notificationCallback,
 				IntPtr.Zero,

--- a/Source/ManagedNativeWifi/Win32/NativeMethod.cs
+++ b/Source/ManagedNativeWifi/Win32/NativeMethod.cs
@@ -903,6 +903,117 @@ internal static class NativeMethod
 		wlan_notification_acm_end
 	}
 
+	/// <summary>
+	/// WLAN_NOTIFICATION_MSM enumeration:
+	/// https://learn.microsoft.com/en-us/windows/win32/api/wlanapi/ne-wlanapi-wlan_notification_msm-r1
+	/// </summary>
+	public enum WLAN_NOTIFICATION_MSM : uint
+	{
+		/// <summary>
+		/// <para>Start of MSM notifications.</para>
+		/// </summary>
+		wlan_notification_msm_start = 0,
+
+		/// <summary>
+		/// <para>A wireless device is in the process of associating with an access point or a peer station.</para>
+		/// <para>The pData member points to a WLAN_MSM_NOTIFICATION_DATA structure that contains connection-related information</para>
+		/// </summary>
+		wlan_notification_msm_associating,
+
+		/// <summary>
+		/// <para>The wireless device has associated with an access point or a peer station.</para>
+		/// <para>The pData member points to a WLAN_MSM_NOTIFICATION_DATA structure that contains connection-related information.</para>
+		/// </summary>
+		wlan_notification_msm_associated,
+
+		/// <summary>
+		/// <para>The wireless device is in the process of authenticating.</para>
+		/// <para>The pData member of the WLAN_NOTIFICATION_DATA structure points to a WLAN_MSM_NOTIFICATION_DATA structure that contains connection-related information.</para>
+		/// </summary>
+		wlan_notification_msm_authenticating,
+
+		/// <summary>
+		/// <para>The wireless device is associated with an access point or a peer station, keys have been exchanged, and the wireless device is available to send data.</para>
+		/// <para>The pData member points to a WLAN_MSM_NOTIFICATION_DATA structure that contains connection-related information.</para>
+		/// </summary>
+		wlan_notification_msm_connected,
+
+		/// <summary>
+		/// <para>The wireless device is connected to an access point and has initiated roaming to another access point.</para>
+		/// <para>The pData member points to a WLAN_MSM_NOTIFICATION_DATA structure that contains connection-related information.</para>
+		/// </summary>
+		wlan_notification_msm_roaming_start,
+
+		/// <summary>
+		/// <para>The wireless device was connected to an access point and has completed roaming to another access point.</para>
+		/// <para>The pData member points to a WLAN_MSM_NOTIFICATION_DATA structure that contains connection-related information.</para>
+		/// </summary>
+		wlan_notification_msm_roaming_end,
+
+		/// <summary>
+		/// <para>The radio state for an adapter has changed. Each physical layer (PHY) has its own radio state. The radio for an adapter is switched off when the radio state of every PHY is off.</para>
+		/// <para>The pData member points to a WLAN_PHY_RADIO_STATE structure that identifies the new radio state.</para>
+		/// </summary>
+		wlan_notification_msm_radio_state_change,
+
+		/// <summary>
+		/// <para>A signal quality change for the currently associated access point or peer station.</para>
+		/// <para>The pData member points to a ULONG value for the WLAN_SIGNAL_QUALITY that identifies the new signal quality.</para>
+		/// </summary>
+		wlan_notification_msm_signal_quality_change,
+
+		/// <summary>
+		/// <para>A wireless device is in the process of disassociating from an access point or a peer station.</para>
+		/// <para>The pData member points to a WLAN_MSM_NOTIFICATION_DATA structure that contains connection-related information.</para>
+		/// </summary>
+		wlan_notification_msm_disassociating,
+
+		/// <summary>
+		/// <para>The wireless device is not associated with an access point or a peer station.</para>
+		/// <para>The pData member points to a WLAN_MSM_NOTIFICATION_DATA structure that contains connection-related information. The wlanReasonCode member of the WLAN_MSM_NOTIFICATION_DATA structure indicates the reason for the disconnect.</para>
+		/// </summary>
+		wlan_notification_msm_disconnected,
+
+		/// <summary>
+		/// <para>A peer has joined an adhoc network.</para>
+		/// <para>The pData member points to a WLAN_MSM_NOTIFICATION_DATA structure that contains connection-related information.</para>
+		/// </summary>
+		wlan_notification_msm_peer_join,
+
+		/// <summary>
+		/// <para>A peer has left an adhoc network.</para>
+		/// <para>The pData member of the WLAN_NOTIFICATION_DATA structure points to a WLAN_MSM_NOTIFICATION_DATA structure that contains connection-related information.</para>
+		/// </summary>
+		wlan_notification_msm_peer_leave,
+
+		/// <summary>
+		/// <para>A wireless adapter has been removed from the local computer.</para>
+		/// <para>The pData member points to a WLAN_MSM_NOTIFICATION_DATA structure that contains connection-related information.</para>
+		/// </summary>
+		wlan_notification_msm_adapter_removal,
+
+		/// <summary>
+		/// <para>The operation mode of the wireless device has changed.</para>
+		/// <para>The pData member points to a ULONG that identifies the new operation mode.</para>
+		/// </summary>
+		wlan_notification_msm_adapter_operation_mode_change,
+
+		/// <summary>
+		/// <para>The current link quality has degraded, but the system has not yet disconnected or reconnected.</para>
+		/// </summary>
+		wlan_notification_msm_link_degraded,
+
+		/// <summary>
+		/// <para>The link quality of the current Wi-Fi connection has improved after a previous degradation, without a disconnection.</para>
+		/// </summary>
+		wlan_notification_msm_link_improved,
+
+		/// <summary>
+		/// <para>End of MSM notifications.</para>
+		/// </summary>
+		wlan_notification_msm_end
+	}
+
 	#endregion
 
 	public const uint WLAN_AVAILABLE_NETWORK_INCLUDE_ALL_ADHOC_PROFILES = 0x00000001;


### PR DESCRIPTION
I've added notifcation for `WLAN_NOTIFICATION_MSM `to get the `wlan_notification_msm_radio_state_change` and `wlan_notification_msm_signal_quality_change`. Now NativeWifiPlayer have two new events: `EventHandler<RadioStateChangedEventArgs> RadioStateChanged` and ` EventHandler<SignalQualityChangedEventArgs> SignalQualityChanged`.

I've added two functions to test both new events in ManagedNativeWifi.Demo project.