### PR TITLE
Added support to real-time connection quality

### DIFF
--- a/Source/ManagedNativeWifi.Demo/Program.cs
+++ b/Source/ManagedNativeWifi.Demo/Program.cs
@@ -22,6 +22,7 @@ class Program
 
 		//CheckRadioStateEvents();
 		//CheckSignalQualityEvents();
+		//GetRealtimeConnectionQualityInfo();
 	}
 
 	private static void ShowInformation()
@@ -225,6 +226,38 @@ class Program
 		{
 			Trace.WriteLine($"{{Interface: ({e.InterfaceId})");
 			Trace.WriteLine($" SignalQuality: {e.SignalQuality}}}");
+		}
+	}
+
+	private static void GetRealtimeConnectionQualityInfo()
+	{
+		foreach (var interfaceInfo in NativeWifi.EnumerateInterfaces())
+		{
+			var connectionQualityInfo = NativeWifi.GetConnectionQualityInfo(interfaceInfo.Id);
+			if (connectionQualityInfo is null)
+				continue;
+
+			Trace.WriteLine($"{{Interface: {interfaceInfo.Description} ({interfaceInfo.Id})");
+			Trace.WriteLine($" Id: {connectionQualityInfo.Id}");
+			Trace.WriteLine($" LinkQuality: {connectionQualityInfo.LinkQuality}");
+			Trace.WriteLine($" RxRate: {connectionQualityInfo.RxRate} Kbps");
+			Trace.WriteLine($" TxRate: {connectionQualityInfo.TxRate} Kbps");
+			Trace.WriteLine($" IsMultiLinkOperation: {connectionQualityInfo.IsMultiLinkOperation}");
+
+			if (connectionQualityInfo.Links.Count == 0)
+				continue;
+
+			Trace.WriteLine($" Links ({connectionQualityInfo.Links.Count}) :");
+
+			foreach (var link in connectionQualityInfo.Links)
+			{
+				Trace.WriteLine($"\t{{LinkId: {link.LinkId}");
+				Trace.WriteLine($"\tRssi: {link.Rssi}");
+				Trace.WriteLine($"\tBandwidth: {link.Bandwidth} MHz");
+				Trace.WriteLine($"\tFrequency: {link.Frequency} MHz}}");
+			}
+
+			Trace.WriteLine($"}}");
 		}
 	}
 }

--- a/Source/ManagedNativeWifi/ConnectionQualityInfo.cs
+++ b/Source/ManagedNativeWifi/ConnectionQualityInfo.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ManagedNativeWifi;
+
+/// <summary>
+/// Wireless interface connection quality information
+/// </summary>
+public class ConnectionQualityInfo
+{
+	/// <summary>
+	/// Interface ID
+	/// </summary>
+	public Guid Id { get; }
+
+	/// <summary>
+	/// Link Quality (0-100)
+	/// </summary>
+	public int LinkQuality { get; }
+
+	/// <summary>
+	/// Receive Rate (Kbps)
+	/// </summary>
+	public int RxRate { get; }
+
+	/// <summary>
+	/// Transmit Rate (Kbps)
+	/// </summary>
+	public int TxRate { get; }
+
+	/// <summary>
+	/// Indicates whether this is a Multi-Link Operation (MLO) connection
+	/// </summary>
+	public bool IsMultiLinkOperation { get; }
+
+	/// <summary>
+	/// Link information for each radio link in the connection
+	/// </summary>
+	public IReadOnlyList<ConnectionQualityLinkInfo> Links { get; }
+
+	internal ConnectionQualityInfo(
+		Guid id,
+		int linkQuality,
+		int rxRate,
+		int txRate,
+		bool isMultiLinkOperation,
+		IEnumerable<ConnectionQualityLinkInfo> links)
+	{
+		Id = id;
+		LinkQuality = linkQuality;
+		RxRate = rxRate;
+		TxRate = txRate;
+		IsMultiLinkOperation = isMultiLinkOperation;
+		Links = Array.AsReadOnly(links?.ToArray() ?? []);
+	}
+}

--- a/Source/ManagedNativeWifi/ConnectionQualityLinkInfo.cs
+++ b/Source/ManagedNativeWifi/ConnectionQualityLinkInfo.cs
@@ -1,0 +1,39 @@
+﻿namespace ManagedNativeWifi;
+
+/// <summary>
+/// Information about an individual radio link in a wireless connection
+/// </summary>
+public class ConnectionQualityLinkInfo
+{
+	/// <summary>
+	/// Link ID
+	/// </summary>
+	public byte LinkId { get; }
+
+	/// <summary>
+	/// Received Signal Strength Indicator (dBm)
+	/// </summary>
+	public int Rssi { get; }
+
+	/// <summary>
+	/// Channel Center frequency (KHz)
+	/// </summary>
+	public int Frequency { get; }
+
+	/// <summary>
+	/// Bandwidth (MHz)
+	/// </summary>
+	public int Bandwidth { get; }
+
+	internal ConnectionQualityLinkInfo(
+		byte linkId,
+		int rssi,
+		int frequency,
+		int bandwidth)
+	{
+		LinkId = linkId;
+		Rssi = rssi;
+		Frequency = frequency;
+		Bandwidth = bandwidth;
+	}
+}

--- a/Source/ManagedNativeWifi/NativeWifiPlayer.cs
+++ b/Source/ManagedNativeWifi/NativeWifiPlayer.cs
@@ -310,6 +310,12 @@ public class NativeWifiPlayer : IDisposable
 		NativeWifi.DisconnectNetworkAsync(_client, interfaceId, timeout, cancellationToken);
 
 	/// <summary>
+	/// Gets real-time connection quality information for a specified wireless interface.
+	/// </summary>
+	public ConnectionQualityInfo GetConnectionQualityInfo(Guid interfaceId) =>
+		NativeWifi.GetConnectionQualityInfo(_client, interfaceId);
+
+	/// <summary>
 	/// Whether to throw an exception when any failure occurs
 	/// </summary>
 	public static bool ThrowsOnAnyFailure

--- a/Source/ManagedNativeWifi/Win32/NativeMethod.cs
+++ b/Source/ManagedNativeWifi/Win32/NativeMethod.cs
@@ -585,6 +585,28 @@ internal static class NativeMethod
 		public string strProfileXml;
 	}
 
+	[StructLayout(LayoutKind.Sequential)]
+	public struct WLAN_REALTIME_CONNECTION_QUALITY_LINK_INFO
+	{
+		public byte ucLinkID;
+		public uint ulChannelCenterFrequencyMhz;
+		public uint ulBandwidth;
+		public int lRssi;
+		public WLAN_RATE_SET wlanRateSet;
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	public struct WLAN_REALTIME_CONNECTION_QUALITY
+	{
+		public DOT11_PHY_TYPE dot11PhyType;
+		public uint ulLinkQuality;
+		public uint ulRxRate;
+		public uint ulTxRate;
+		[MarshalAs(UnmanagedType.Bool)]
+		public bool bIsMLOConnection;
+		public uint ulNumLinks;
+	}
+
 	#endregion
 
 	#region Enum
@@ -719,6 +741,10 @@ internal static class NativeMethod
 		wlan_intf_opcode_certified_safe_mode,
 		wlan_intf_opcode_hosted_network_capable,
 		wlan_intf_opcode_management_frame_protection_capable,
+		wlan_intf_opcode_secondary_sta_interfaces,
+		wlan_intf_opcode_secondary_sta_synchronized_connections,
+		wlan_intf_opcode_realtime_connection_quality,
+		wlan_intf_opcode_qos_info,
 		wlan_intf_opcode_autoconf_end = 0x0fffffff,
 		wlan_intf_opcode_msm_start = 0x10000100,
 		wlan_intf_opcode_statistics,


### PR DESCRIPTION
Introduced `GetConnectionQuality(Guid interfaceId)` methods in both `NativeWifi` and `NativeWifiPlayer` classes for simplified access to connection quality information. Updated `BaseMethod` to interact with the WLAN API for real-time data retrieval. Defined new structures and classes to encapsulate connection quality and link details.